### PR TITLE
Fix sampling frequency check for rates not dividing 1000 (e.g. 120 Hz)

### DIFF
--- a/src/pupeyes/pupil.py
+++ b/src/pupeyes/pupil.py
@@ -225,7 +225,18 @@ class PupilProcessor:
                 print(f'Sampling frequency check passed. Sampling rate: {sampling_rate}Hz')
                 check_pass = True
         else:
-            raise ValueError('Sampling frequency is not consistent!')
+            delta_t = 1000/sampling_rate
+            abs_deviation = np.abs(diff - delta_t)
+            
+            # Deviations up to 1ms are possible if 1000 is not divisble by the sampling frequency.
+            # For instance 1000/120 = 8.33. Diff will be [8,9]
+            consistent = bool(np.all(abs_deviation < 1))
+
+            if not consistent:
+                raise ValueError('Sampling frequency is not consistent!')
+            else:
+                print(f'Sampling frequency check passed. Sampling rate: {sampling_rate}Hz')
+                check_pass = True
         
         return check_pass
 


### PR DESCRIPTION
Problem

The sampling-frequency consistency check assumed that consecutive-sample timestamp diffs are always identical, which only holds when 1000 / sampling_rate is an integer number of milliseconds. For rates like 120 Hz, the true inter-sample interval is 8.33 ms, so millisecond-rounded timestamps alternate between 8 ms and 9 ms diffs. diff.unique() then returns two values instead of one, and the check incorrectly raised Sampling frequency is not consistent! even though the sampling rate was in fact correct.

Fix

When diff has more than one unique value, instead of immediately failing, the check now compares each observed diff against the expected interval 1000/sampling_rate and allows deviations of up to 1 ms — the maximum rounding error possible when the true interval isn't a whole number of milliseconds (e.g. 120 Hz → 8.33 ms → observed diffs of 8 and 9 ms, each within 1 ms of the true value). If all diffs fall within that tolerance, the check passes; otherwise it still raises as before.

The single-diff case is unchanged.

Testing

Verified against data sampled at 120 Hz, which previously raised Sampling frequency is not consistent! and now passes correctly. Rates that divide evenly into 1000 (e.g. 250 Hz, 500 Hz) are unaffected and continue to hit the len(diff) == 1 branch as before.