### PR TITLE
Fix sampling frequency check for non-divisor rates, with per-trial validation

### DIFF
--- a/src/pupeyes/pupil.py
+++ b/src/pupeyes/pupil.py
@@ -225,7 +225,18 @@ class PupilProcessor:
                 print(f'Sampling frequency check passed. Sampling rate: {sampling_rate}Hz')
                 check_pass = True
         else:
-            raise ValueError('Sampling frequency is not consistent!')
+            delta_t = 1000/sampling_rate
+            abs_deviation = np.abs(diff - delta_t)
+            
+            # Deviations up to 1ms are possible if 1000 is not divisble by the sampling frequency.
+            # For instance 1000/120 = 8.33. Diff will be [8,9]
+            consistent = bool(np.all(abs_deviation < 1))
+
+            if not consistent:
+                raise ValueError('Sampling frequency is not consistent!')
+            else:
+                print(f'Sampling frequency check passed. Sampling rate: {sampling_rate}Hz')
+                check_pass = True
         
         return check_pass
 

--- a/src/pupeyes/pupil.py
+++ b/src/pupeyes/pupil.py
@@ -215,30 +215,31 @@ class PupilProcessor:
         
         data = self.data if data is None else data
         sampling_rate = self.samp_freq if sampling_rate is None else sampling_rate
-        check_pass = False
-        # check if the difference between consecutive samples is equal to a fixed value
-        diff = data.groupby(self.trial_identifier, sort=False)[self.time_col].diff().dropna().unique()
-        if len(diff) == 1:
-            if 1000/diff[0] != sampling_rate:
-                raise ValueError(f'Actual sampling frequency {1000/diff[0]}Hz does not match the provided sampling frequency {sampling_rate}Hz!')
-            else:
-                print(f'Sampling frequency check passed. Sampling rate: {sampling_rate}Hz')
-                check_pass = True
-        else:
-            delta_t = 1000/sampling_rate
-            abs_deviation = np.abs(diff - delta_t)
-            
-            # Deviations up to 1ms are possible if 1000 is not divisble by the sampling frequency.
-            # For instance 1000/120 = 8.33. Diff will be [8,9]
-            consistent = bool(np.all(abs_deviation < 1))
+        delta_t = 1000/sampling_rate
 
-            if not consistent:
-                raise ValueError('Sampling frequency is not consistent!')
-            else:
-                print(f'Sampling frequency check passed. Sampling rate: {sampling_rate}Hz')
-                check_pass = True
-        
-        return check_pass
+        # Timestamps are rounded to integer milliseconds, so when 1000 is not divisible
+        # by the sampling frequency each interval may deviate from the true interval by
+        # up to 1ms. For instance 1000/120 = 8.33, so diffs alternate between 8 and 9.
+        diff = data.groupby(self.trial_identifier, sort=False)[self.time_col].diff().dropna().unique()
+        if not np.all(np.abs(diff - delta_t) < 1):
+            if len(diff) == 1:
+                raise ValueError(f'Actual sampling frequency {1000/diff[0]}Hz does not match the provided sampling frequency {sampling_rate}Hz!')
+            raise ValueError('Sampling frequency is not consistent!')
+
+        # The per-interval tolerance alone would accept a mixture of two different
+        # uniform rates (e.g. one trial all 8ms and another all 9ms, both within 1ms
+        # of 8.33). Rounding shifts a trial's first and last timestamps by at most
+        # 0.5ms each, so each trial's mean interval must lie within 1/n of delta_t.
+        stats = data.groupby(self.trial_identifier, sort=False)[self.time_col].agg(['count', 'first', 'last'])
+        stats = stats[stats['count'] > 1]
+        n_intervals = stats['count'] - 1
+        mean_deviation = np.abs((stats['last'] - stats['first']) / n_intervals - delta_t)
+        bad_trials = mean_deviation > 1/n_intervals + 1e-9
+        if bad_trials.any():
+            raise ValueError(f'Sampling frequency is not consistent: mean sampling interval deviates from the expected {delta_t:.2f}ms in trial(s) {list(stats.index[bad_trials])}!')
+
+        print(f'Sampling frequency check passed. Sampling rate: {sampling_rate}Hz')
+        return True
 
     def deblink(self, suffix='_db'):
         """


### PR DESCRIPTION
Builds on #10 (includes @Constantin-Jehn's commit) and addresses the two issues found in [its review](https://github.com/HanZhang-psych/pupeyes/pull/10#pullrequestreview-3186267298). If this is merged, #10 can be closed.

## Changes to `check_sampling_frequency`

1. **Unified tolerance check for all diffs.** The `len(diff) == 1` branch previously required exact equality, so a short recording at a non-divisor rate whose diffs happened to all be 8 ms (no 9 ms tick yet) still raised a spurious `Actual sampling frequency 125.0Hz does not match... 120Hz` error. Now every observed interval is checked against the expected `1000/sampling_rate` with the 1 ms rounding tolerance, and the informative actual-vs-provided error message is preserved when all diffs share a single value.

2. **Per-trial mean-interval check.** Checking only `unique()` diff values against a flat 1 ms tolerance would accept a mixture of two different uniform rates — e.g. one trial recorded at 125 Hz (all 8 ms diffs) and another at ~111 Hz (all 9 ms diffs) both pass as "consistent 120 Hz". Since timestamp rounding can shift a trial's first and last timestamps by at most 0.5 ms each, a trial's mean interval over `n` intervals can legitimately deviate from `1000/sampling_rate` by at most `1/n` ms. Trials exceeding that bound now raise, with the offending trials named in the error. Genuine 120 Hz data with 8/9 ms alternation still passes.

## Testing

- Verified against nine scenarios: uniform 250/500/1000 Hz data, 120 Hz data with 8/9 alternation, short 120 Hz trials with only 8 ms diffs (passes, no longer a spurious mismatch), all-8 ms data claimed as 120 Hz over many intervals (correctly raises — such data is really 125 Hz), the 125 Hz + 111 Hz trial mixture claimed as 120 Hz (correctly raises), a plain wrong-rate claim (raises the informative mismatch error), and irregular/dropped-sample data (raises).
- Existing test suite passes (19 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXVW87E3bP2RYbvwPA4PeZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXVW87E3bP2RYbvwPA4PeZ)_